### PR TITLE
Allow to create database with autoscale shared throughput

### DIFF
--- a/src/Cloud.Core.Storage.AzureCosmos/Config/CosmosConfig.cs
+++ b/src/Cloud.Core.Storage.AzureCosmos/Config/CosmosConfig.cs
@@ -36,6 +36,16 @@
         public bool CreateDatabaseIfNotExists { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether Database is created with autoscale shared throughput.
+        /// </summary>
+        public bool AutoscaleDatabaseThroughput { get; set; }
+
+        /// <summary>
+        /// Gets or sets the max throughput to autoscale Database
+        /// </summary>
+        public int MaxThroughput { get; set; } = 4000;
+
+        /// <summary>
         /// Gets or sets the list of tables to be created during initialisation.
         /// </summary>
         /// <value>The list of tables to create.</value>

--- a/src/Cloud.Core.Storage.AzureCosmos/CosmosStorage.cs
+++ b/src/Cloud.Core.Storage.AzureCosmos/CosmosStorage.cs
@@ -535,6 +535,8 @@
         private readonly string _instanceName;
         private readonly string _subscriptionId;
         private readonly bool _createIfNotExists;
+        private readonly bool _autoscaleDatabaseThroughput;
+        private readonly int _maxThroughput;
         private readonly string[] _createTableNames;
 
         private const string DefaultPartitionKeyPath = "/_partitionKey";
@@ -581,7 +583,11 @@
             // Create the database if it does not exist and been instructed to.
             if (_createIfNotExists)
             {
-                _cloudClient.CreateDatabaseIfNotExistsAsync(DatabaseName).GetAwaiter().GetResult();
+                var throughputProperties = _autoscaleDatabaseThroughput
+                    ? ThroughputProperties.CreateAutoscaleThroughput(_maxThroughput)
+                    : null;
+
+                _cloudClient.CreateDatabaseIfNotExistsAsync(DatabaseName, throughputProperties).GetAwaiter().GetResult();
             }
 
             // Create any tables required up front.
@@ -611,6 +617,8 @@
 
             _createIfNotExists = config.CreateDatabaseIfNotExists;
             _createTableNames = config.CreateTables;
+            _maxThroughput = config.MaxThroughput;
+            _autoscaleDatabaseThroughput = config.AutoscaleDatabaseThroughput;
         }
 
         /// <summary>
@@ -632,6 +640,8 @@
             _subscriptionId = config.SubscriptionId;
             _createIfNotExists = config.CreateDatabaseIfNotExists;
             _createTableNames = config.CreateTables;
+            _maxThroughput = config.MaxThroughput;
+            _autoscaleDatabaseThroughput = config.AutoscaleDatabaseThroughput;
         }
 
         /// <summary>
@@ -653,6 +663,8 @@
             _subscriptionId = config.SubscriptionId;
             _createIfNotExists = config.CreateDatabaseIfNotExists;
             _createTableNames = config.CreateTables;
+            _maxThroughput = config.MaxThroughput;
+            _autoscaleDatabaseThroughput = config.AutoscaleDatabaseThroughput;
         }
 
 


### PR DESCRIPTION
Database is created without throughput properties. Then, by default, containers are created without shared throughput.

This piece of code allow us to create database with autoscale shared throughput if database does not exist.